### PR TITLE
Add support for supportedRegions param

### DIFF
--- a/Example/App.tsx
+++ b/Example/App.tsx
@@ -18,7 +18,8 @@ const requestDisbursementData: ApplePayDisbursementRequest = {
   merchantIdentifier: 'merchant.com.payture.applepay.Busfor',
   regionCode: 'US',
   paymentSummaryItems: [{ amount: '100.00', label: 'Business label' }],
-  supportedNetworks: ['mastercard', 'visa']
+  supportedNetworks: ['mastercard', 'visa'],
+  supportedRegions: ['US']
 }
 
 export const App = () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,8 @@ export interface ApplePayDisbursementRequest {
   merchantIdentifier: string
   paymentSummaryItems: ApplePayPaymentSummaryItem[]
   regionCode: string
-  supportedNetworks: ApplePayCardNetwork[]
+  supportedNetworks: ApplePayCardNetwork[],
+  supportedRegions: string[]
 }
 
 export interface ApplePayPaymentSummaryItem {

--- a/ios/RNApplePay.m
+++ b/ios/RNApplePay.m
@@ -52,6 +52,7 @@ RCT_EXPORT_METHOD(requestDisbursement:(NSDictionary *)props promiseWithResolver:
                                           currencyCode:props[@"currencyCode"]
                                           regionCode:props[@"regionCode"]
                                           supportedNetworks:[self getSupportedNetworks:props]
+                                          supportedRegions:props[@"supportedRegions"]
                                           merchantCapabilities:[self getMerchantCapabilities:props]
                                           summaryItems:[self getDisbursementSummaryItems:props]];
 


### PR DESCRIPTION
This PR adds support for the `supportedRegions` param that's available for disbursement requests.